### PR TITLE
feat: Add SliderServices component to home page

### DIFF
--- a/src/components/pages/home/SliderServices.astro
+++ b/src/components/pages/home/SliderServices.astro
@@ -1,0 +1,38 @@
+---
+import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
+import Headline from '~/components/ui/Headline.astro';
+import ItemGrid2 from '~/components/ui/ItemGrid2.astro';
+import type { Features as Props } from '~/types';
+
+const {
+  title = await Astro.slots.render('title'),
+  subtitle = await Astro.slots.render('subtitle'),
+  tagline = await Astro.slots.render('tagline'),
+  items = [],
+  columns = 3,
+  defaultIcon,
+
+  id,
+  isDark = false,
+  classes = {},
+  bg = await Astro.slots.render('bg'),
+} = Astro.props;
+---
+
+<WidgetWrapper id={id} isDark={isDark} containerClass={`max-w-7xl mx-auto ${classes?.container ?? ''}`} bg={bg}>
+  <Headline title={title} subtitle={subtitle} tagline={tagline} classes={classes?.headline as Record<string, string>} />
+  <ItemGrid2
+    items={items}
+    columns={columns}
+    defaultIcon={defaultIcon}
+    classes={{
+      container: 'gap-4 md:gap-6',
+      // panel:
+      //       'rounded-lg shadow-[0_4px_30px_rgba(0,0,0,0.1)] dark:shadow-[0_4px_30px_rgba(0,0,0,0.1)] backdrop-blur border border-[#ffffff29] bg-white dark:bg-slate-900 p-6',
+      panel:
+        'text-center bg-page items-center md:text-left rtl:md:text-right md:items-start p-6 p-6 rounded-md shadow-xl dark:shadow-none dark:border dark:border-slate-800',
+      icon: 'w-12 h-12 mb-6 text-primary',
+      ...((classes?.items as {}) ?? {}),
+    }}
+  />
+</WidgetWrapper>

--- a/src/components/ui/ItemGrid2.astro
+++ b/src/components/ui/ItemGrid2.astro
@@ -1,23 +1,18 @@
 ---
-import type { ItemGrid as Props } from "~/types";
-import { Icon } from "astro-icon/components";
-import { twMerge } from "tailwind-merge";
-import Button from "./Button.astro";
+import type { ItemGrid as Props } from '~/types';
+import { Icon } from 'astro-icon/components';
+import { twMerge } from 'tailwind-merge';
+import Button from './Button.astro';
+
+const { items = [], columns, defaultIcon = '', classes = {} } = Astro.props;
 
 const {
-  items = [],
-  columns,
-  defaultIcon = "",
-  classes = {},
-} = Astro.props;
-
-const {
-  container: containerClass = "",
+  container: containerClass = 'overflow-x-auto',
   // container: containerClass = "sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3",
-  panel: panelClass = "",
-  title: titleClass = "",
-  description: descriptionClass = "",
-  icon: defaultIconClass = "text-primary",
+  panel: panelClass = '',
+  title: titleClass = '',
+  description: descriptionClass = '',
+  icon: defaultIconClass = 'text-primary',
 } = classes;
 ---
 
@@ -26,69 +21,37 @@ const {
     <div
       class={twMerge(
         `grid gap-8 gap-x-12 sm:gap-y-8 ${
-          columns === 4
-            ? "lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2"
-            : columns === 3
-            ? "lg:grid-cols-3 sm:grid-cols-2"
-            : columns === 2
-            ? "sm:grid-cols-2 "
-            : ""
+          columns === 6
+            ? ' grid-cols-2 lg:grid-cols-6 md:grid-cols-5 sm:grid-cols-4'
+            : columns === 5
+              ? 'lg:grid-cols-5 md:grid-cols-4 sm:grid-cols-3'
+              : columns === 4
+                ? 'lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2'
+                : columns === 3
+                  ? 'grid-cols-2 lg:grid-cols-3 sm:grid-cols-2'
+                  : columns === 2
+                    ? 'sm:grid-cols-2 '
+                    : ''
         }`,
         containerClass
       )}
     >
-      {items.map(
-        ({
-          title,
-          description,
-          icon,
-          callToAction,
-          classes: itemClasses = {},
-        }) => (
-          <div
-            class={twMerge(
-              "relative flex flex-col",
-              panelClass,
-              itemClasses?.panel
-            )}
-          >
-            {(icon || defaultIcon) && (
-              <Icon
-                name={icon || defaultIcon}
-                class={twMerge(
-                  "mb-2 w-10 h-10",
-                  defaultIconClass,
-                  itemClasses?.icon
-                )}
-              />
-            )}
-            <div
-              class={twMerge(
-                "text-xl font-bold",
-                titleClass,
-                itemClasses?.title
-              )}
-            >
-              {title}
+      {items.map(({ title, description, icon, callToAction, classes: itemClasses = {} }) => (
+        <div class={twMerge('relative flex flex-col', panelClass, itemClasses?.panel)}>
+          {(icon || defaultIcon) && (
+            <Icon name={icon || defaultIcon} class={twMerge('mb-2 w-10 h-10', defaultIconClass, itemClasses?.icon)} />
+          )}
+          <div class={twMerge('text-xl font-bold', titleClass, itemClasses?.title)}>{title}</div>
+          {description && (
+            <p class={twMerge('text-muted mt-2', descriptionClass, itemClasses?.description)} set:html={description} />
+          )}
+          {callToAction && (
+            <div class="mt-2">
+              <Button {...callToAction} />
             </div>
-            {description && (
-              <p
-                class={twMerge(
-                  "text-muted mt-2",
-                  descriptionClass,
-                  itemClasses?.description
-                )}
-                set:html={description}
-              />
-            )}
-            {callToAction && (
-              <div class="mt-2">
-                <Button {...callToAction} />
-              </div>
-            )}
-          </div>
-        )
-      )}
+          )}
+        </div>
+      ))}
     </div>
   )
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,12 +7,12 @@ import Features from '~/components/widgets/Features.astro';
 import Features2 from '~/components/widgets/Features2.astro';
 import Steps from '~/components/widgets/Steps.astro';
 import Content from '~/components/widgets/Content.astro';
-import BlogLatestPosts from '~/components/widgets/BlogLatestPosts.astro';
 import FAQs from '~/components/widgets/FAQs.astro';
 import Stats from '~/components/widgets/Stats.astro';
 import CallToAction from '~/components/widgets/CallToAction.astro';
 
 import BannerForm from '~/components/pages/home/Banner-Form.astro';
+import SliderServices from '~/components/pages/home/SliderServices.astro';
 
 const metadata = {
   title: 'Elite Service JC — Housekeeping',
@@ -63,7 +63,7 @@ const metadata = {
       {
         title: 'DURABILITÉ',
         description:
-          "Un de nos fondements qui entoure notre éthique dans l’entreprise est d’ajouter de la valeur à notre société. On travaille pour promouvoir le respect de notre équipe envers la société et l’environnement avec l’utilisation des produits non-chimiques.",
+          'Un de nos fondements qui entoure notre éthique dans l’entreprise est d’ajouter de la valeur à notre société. On travaille pour promouvoir le respect de notre équipe envers la société et l’environnement avec l’utilisation des produits non-chimiques.',
         icon: 'tabler:arrows-right-left',
       },
       {
@@ -74,6 +74,44 @@ const metadata = {
       },
     ]}
   />
+
+  <!-- HighlightedPosts Widget ******* -->
+
+  <SliderServices
+    title="Most used widgets"
+    subtitle="Provides frequently used components for building websites using Tailwind CSS"
+    tagline="Components"
+    items={[
+      {
+        title: 'RÉSIDENCES INMOBILIÈRES',
+        icon: 'flat-color-icons:template',
+      },
+      {
+        title: 'RÉSIDENCES D’AÎNÉS',
+        icon: 'flat-color-icons:gallery',
+      },
+      {
+        title: 'BUREAUX PROFESSIONNELS',
+        icon: 'flat-color-icons:approval',
+      },
+      {
+        title: 'CENTRE DE SANTÉ',
+        icon: 'flat-color-icons:document',
+      },
+      {
+        title: 'GARDERIES/ÉCOLES/CPE',
+        icon: 'flat-color-icons:advertising',
+      },
+      {
+        title: 'LOCAUX COMMERCIAUX',
+        icon: 'flat-color-icons:currency-exchange',
+      },
+    ]}
+  >
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </SliderServices>
 
   <!-- Content Widget **************** -->
 
@@ -105,7 +143,7 @@ const metadata = {
   >
     <Fragment slot="content">
       <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">Building on modern foundations</h3>
-       Gain a competitive advantage by incorporating industry leading practices
+      Gain a competitive advantage by incorporating industry leading practices
     </Fragment>
 
     <Fragment slot="bg">
@@ -285,16 +323,6 @@ const metadata = {
       <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
     </Fragment>
   </Features2>
-
-  <!-- HighlightedPosts Widget ******* -->
-
-  <BlogLatestPosts
-    title="Find out more content in our Blog"
-    information={`The blog is used to display AstroWind documentation.
-                        Each new article will be an important step that you will need to know to be an expert in creating a website using Astro + Tailwind CSS.
-                        Astro is a very interesting technology. Thanks.
-                `}
-  />
 
   <!-- FAQs Widget ******************* -->
 


### PR DESCRIPTION
This commit adds the SliderServices component to the home page. The SliderServices component displays a slider with frequently used widgets for building websites using Tailwind CSS. It includes titles and icons for different types of services, such as residential properties, elderly residences, professional offices, health centers, daycares/schools, and commercial spaces. This addition enhances the functionality and visual appeal of the home page.